### PR TITLE
fix: update API endpoint to use production URL for job fetching

### DIFF
--- a/app/jobs/[id]/page.jsx
+++ b/app/jobs/[id]/page.jsx
@@ -16,7 +16,7 @@ export default function JobDetails() {
   useEffect(() => {
     const fetchJob = async () => {
       try {
-        const response = await fetch(`http://localhost:3000/api/jobs/${id}`, {
+        const response = await fetch(`https://kuvoshadmin.vercel.app/api/jobs/${id}`, {
           method: 'GET',
         });
   


### PR DESCRIPTION
This pull request includes a single change to the `JobDetails` component in `app/jobs/[id]/page.jsx`. The change updates the API endpoint URL from a local development server to a production server.

* `app/jobs/[id]/page.jsx`: Updated the `fetch` call in the `fetchJob` function to use the production API endpoint `https://kuvoshadmin.vercel.app/api/jobs/${id}` instead of the local development URL `http://localhost:3000/api/jobs/${id}`. ([app/jobs/[id]/page.jsxL19-R19](diffhunk://#diff-ab67c628fd9a2d37201d3d13212f2ff073c0d00c221db0ae53a49b07c3cb50b2L19-R19))